### PR TITLE
Fixed file matching bug

### DIFF
--- a/application/libraries/MY_Email.php
+++ b/application/libraries/MY_Email.php
@@ -193,15 +193,15 @@ class MY_Email extends CI_Email
 			{
 
 				$f = basename($filename);
-				$f['name'] = trim($f);
+				$ft = trim($f);
 				$cid = 'inl_'.$i;
 				$cid1 = 'cid:'.$cid;
 				$h .= "Content-ID: <".$cid.">".$this->newline;
-				$body = $this->matched_replace_between($body, 'src=3D"', '"', $f['name'], $cid1, 3);
-				$body = $this->matched_replace_between($body, 'href=3D"', '"', $f['name'], $cid1, 3);
-				$body = $this->matched_replace_between($body, 'src="', '"', $f['name'], $cid1, 3);
-				$body = $this->matched_replace_between($body, 'href="', '"', $f['name'], $cid1, 3);
-				$body = $this->matched_replace_between($body, 'url(\'', '\');', $f['name'], $cid1, 3);
+				$body = $this->matched_replace_between($body, 'src=3D"', '"', $ft, $cid1, 3);
+				$body = $this->matched_replace_between($body, 'href=3D"', '"', $ft, $cid1, 3);
+				$body = $this->matched_replace_between($body, 'src="', '"', $ft, $cid1, 3);
+				$body = $this->matched_replace_between($body, 'href="', '"', $ft, $cid1, 3);
+				$body = $this->matched_replace_between($body, 'url(\'', '\');', $ft, $cid1, 3);
 			}
 
 			$attachment[$z++] = $h;


### PR DESCRIPTION
f['name'] becomes "i" which matched in my case all the inline images. The result was that all the images were replaced by the last image.
I renamed f['name'] to ft (FileTrimmed), now it should work just fine.
